### PR TITLE
Fix importer

### DIFF
--- a/cmd/octillery/main.go
+++ b/cmd/octillery/main.go
@@ -300,11 +300,10 @@ func (cmd *ImportCommand) values(record []string, types []GoType, columns []stri
 			}
 			values = append(values, value)
 		case GoString:
-			unquotedString, err := strconv.Unquote(fmt.Sprintf("\"%s\"", v))
-			if err != nil {
-				values = append(values, v)
-			} else {
+			if unquotedString, err := strconv.Unquote(fmt.Sprintf("\"%s\"", v)); err == nil {
 				values = append(values, unquotedString)
+			} else {
+				values = append(values, v)
 			}
 		case GoBytes:
 			values = append(values, []byte(v))

--- a/cmd/octillery/main.go
+++ b/cmd/octillery/main.go
@@ -302,9 +302,10 @@ func (cmd *ImportCommand) values(record []string, types []GoType, columns []stri
 		case GoString:
 			unquotedString, err := strconv.Unquote(fmt.Sprintf("\"%s\"", v))
 			if err != nil {
-				return nil, errors.Wrapf(err, "cannot convert %s to unquoted string", v)
+				values = append(values, v)
+			} else {
+				values = append(values, unquotedString)
 			}
-			values = append(values, unquotedString)
 		case GoBytes:
 			values = append(values, []byte(v))
 		case GoDateFormat:

--- a/octillery.go
+++ b/octillery.go
@@ -19,7 +19,7 @@ import (
 )
 
 // Version is the variable for versioning Octillery
-const Version = "v1.1.0"
+const Version = "v1.1.1"
 
 // LoadConfig load your database configuration file.
 //


### PR DESCRIPTION
If CSV includes "abcde\nfg" , we expect to that it is inserted the following.

```
abcde
fg
```

But, currently inserted value is the following.

```
abcde\nfg
```

So, I fixed this by unquoting with double quotation value.
