### PR TITLE
`transpose` command ignore pkg/mod/go.knocknote.io/octillery for Go Modules

### DIFF
--- a/transposer/inspector.go
+++ b/transposer/inspector.go
@@ -39,12 +39,13 @@ var (
 
 func importDatabaseSQLPackagePatterns() []*regexp.Regexp {
 	patterns := []*regexp.Regexp{}
-	basePath := filepath.Join("go.knocknote.io", "octillery")
+	basePath := filepath.Join("go.knocknote.io", "octillery.*")
 	for _, path := range []string{
 		"algorithm",
 		"connection",
 		"database",
 		"exec",
+		"migrator",
 		"octillery\\.go",
 		"plugin",
 		"printer",


### PR DESCRIPTION
`octillery transpose` ignore `$GOPATH/pkg/mod/go.knocknote.io/octillery@v{version}-{date}-{hash}` pattern, and add `migrator` package to ignore list.