### PR TITLE
Add nil check for getting read/write queries

### DIFF
--- a/database/sql/sql_test.go
+++ b/database/sql/sql_test.go
@@ -607,6 +607,12 @@ func TestTransaction(t *testing.T) {
 	defer db.Close()
 	tx, err := db.Begin()
 	checkErr(t, err)
+	if readQueries := tx.ReadQueries(); len(readQueries) > 0 {
+		t.Fatal("invalid read queries")
+	}
+	if writeQueries := tx.WriteQueries(); len(writeQueries) > 0 {
+		t.Fatal("invalid write queries")
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	t.Run("prepare context", func(t *testing.T) {

--- a/database/sql/tx.go
+++ b/database/sql/tx.go
@@ -75,11 +75,17 @@ func (proxy *Tx) AfterCommitCallback(success func() error, failure func(bool, []
 
 // WriteQueries informations of executed INSERT/UPDATE/DELETE query
 func (proxy *Tx) WriteQueries() []*connection.QueryLog {
+	if proxy.tx == nil {
+		return []*connection.QueryLog{}
+	}
 	return proxy.tx.WriteQueries
 }
 
 // ReadQueries informations of executed SELECT query
 func (proxy *Tx) ReadQueries() []*connection.QueryLog {
+	if proxy.tx == nil {
+		return []*connection.QueryLog{}
+	}
 	return proxy.tx.ReadQueries
 }
 


### PR DESCRIPTION
If application does not call `tx.Query()` or `tx.Exec()`, `*sql.Tx.tx` instance is `nil` .
In this case, `invalid memory address` occur  at `WriteQueries` or `ReadQueries`.  
So I add `nil` check for that.