### PR TITLE
Removal of master-slave vocabulary

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,11 +24,11 @@ type DatabaseConfig struct {
 	// login password to database server
 	Password string `yaml:"password"`
 
-	// master server's dsn list ( currently support single master only )
-	Masters []string `yaml:"master"`
+	// main server's dsn list ( currently support single main only )
+	Mains []string `yaml:"main"`
 
-	// slave server's dsn list ( currently not support )
-	Slaves []string `yaml:"slave"`
+	// subordinate server's dsn list ( currently not support )
+	Subordinates []string `yaml:"subordinate"`
 
 	// backup server's dsn list ( currently not support )
 	Backups []string `yaml:"backup"`

--- a/connection/adapter/plugin/mysql.go
+++ b/connection/adapter/plugin/mysql.go
@@ -63,12 +63,12 @@ func (adapter *MySQLAdapter) NextSequenceID(conn *sql.DB, tableName string) (int
 
 // ExecDDL create database if not exists by database configuration file.
 func (adapter *MySQLAdapter) ExecDDL(config *config.DatabaseConfig) error {
-	if len(config.Masters) > 1 {
-		return errors.New("Sorry, currently supports single master database only")
+	if len(config.Mains) > 1 {
+		return errors.New("Sorry, currently supports single main database only")
 	}
 	dbname := config.NameOrPath
-	for _, master := range config.Masters {
-		serverDsn := fmt.Sprintf("%s:%s@tcp(%s)/", config.Username, config.Password, master)
+	for _, main := range config.Mains {
+		serverDsn := fmt.Sprintf("%s:%s@tcp(%s)/", config.Username, config.Password, main)
 		serverConn, err := sql.Open(config.Adapter, serverDsn)
 		defer serverConn.Close()
 		if err != nil {
@@ -79,17 +79,17 @@ func (adapter *MySQLAdapter) ExecDDL(config *config.DatabaseConfig) error {
 		}
 		return nil
 	}
-	return errors.New("must define 'master' server")
+	return errors.New("must define 'main' server")
 }
 
 // OpenConnection open connection by database configuration file
 func (adapter *MySQLAdapter) OpenConnection(config *config.DatabaseConfig, queryString string) (*sql.DB, error) {
-	if len(config.Masters) > 1 {
-		return nil, errors.New("Sorry, currently supports single master database only")
+	if len(config.Mains) > 1 {
+		return nil, errors.New("Sorry, currently supports single main database only")
 	}
 	dbname := config.NameOrPath
-	for _, master := range config.Masters {
-		dsn := fmt.Sprintf("%s:%s@tcp(%s)/%s?%s", config.Username, config.Password, master, dbname, queryString)
+	for _, main := range config.Mains {
+		dsn := fmt.Sprintf("%s:%s@tcp(%s)/%s?%s", config.Username, config.Password, main, dbname, queryString)
 		debug.Printf("dsn = %s", strings.Replace(dsn, "%", "%%", -1))
 		conn, err := sql.Open(config.Adapter, dsn)
 		if err != nil {
@@ -97,9 +97,9 @@ func (adapter *MySQLAdapter) OpenConnection(config *config.DatabaseConfig, query
 		}
 		return conn, nil
 	}
-	for _, slave := range config.Slaves {
-		dsn := fmt.Sprintf("%s:%s@tcp(%s)/%s?%s", config.Username, config.Password, slave, dbname, queryString)
-		debug.Printf("TODO: not support slave. dsn = %s", dsn)
+	for _, subordinate := range config.Subordinates {
+		dsn := fmt.Sprintf("%s:%s@tcp(%s)/%s?%s", config.Username, config.Password, subordinate, dbname, queryString)
+		debug.Printf("TODO: not support subordinate. dsn = %s", dsn)
 		break
 	}
 
@@ -107,7 +107,7 @@ func (adapter *MySQLAdapter) OpenConnection(config *config.DatabaseConfig, query
 		dsn := fmt.Sprintf("%s:%s@tcp(%s)/%s?%s", config.Username, config.Password, backup, dbname, queryString)
 		debug.Printf("TODO: not support backup. dsn = %s", dsn)
 	}
-	return nil, errors.New("must define 'master' server")
+	return nil, errors.New("must define 'main' server")
 }
 
 // CreateSequencerTableIfNotExists create table for sequencer if not exists

--- a/sqlparser/sqlparser_test.go
+++ b/sqlparser/sqlparser_test.go
@@ -976,7 +976,7 @@ func TestERROR(t *testing.T) {
 		log.Println(err)
 	})
 	t.Run("unsupport query", func(t *testing.T) {
-		query, err := parser.Parse("show slave status")
+		query, err := parser.Parse("show subordinate status")
 		if query != nil {
 			t.Fatal("invalid query value")
 		}


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.